### PR TITLE
panic: runtime error: index out of range [0] with length 0

### DIFF
--- a/cmd/displayers/vm.go
+++ b/cmd/displayers/vm.go
@@ -72,7 +72,9 @@ func (o VMs) TableData(w io.Writer) error {
 		ip := ""
 		if len(vm.Spec.Resources.NicList) > 0 {
 			subnet = vm.Spec.Resources.NicList[0].SubnetReference.Name
-			ip = vm.Status.Resources.NicList[0].IPEndpointList[0].IP
+			if len(vm.Status.Resources.NicList[0].IPEndpointList) > 0 {
+				ip = vm.Status.Resources.NicList[0].IPEndpointList[0].IP
+			}
 		}
 		state := ""
 		if vm.Metadata.ProjectReference != nil {


### PR DESCRIPTION
listing vms would fail for me with following panic. Patch fixes this.

```
panic: runtime error: index out of range [0] with length 0
goroutine 1 [running]:
github.com/simonfuhrer/nutactl/cmd/displayers.VMs.TableData({{{0x0, 0x0}, {0xc000226780, 0x40, 0x50}, 0x0}}, {0xa0e9c0, 0xc000014018})
    ┆   /home/abi/nuta/src/cmd/displayers/vm.go:75 +0x888
```